### PR TITLE
Write send-all! function, keep servers and connections in atoms

### DIFF
--- a/.idea/libraries/Leiningen__org_clojure_data_json_0_2_6.xml
+++ b/.idea/libraries/Leiningen__org_clojure_data_json_0_2_6.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: org.clojure/data.json:0.2.6">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/org/clojure/data.json/0.2.6/data.json-0.2.6.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/README.md
+++ b/README.md
@@ -69,3 +69,22 @@ back.
 
 (stop-all-ws-servers)
 ```
+
+# Use transformer functions when receiving and sending data
+
+```clojure
+(require '[clojure.data.json :as json])
+
+(defn request-handler-json
+    [[action data]]
+    [action
+     (case action
+        "upcase" (request-handler-upcase-string data)
+        data)])
+
+; json/read-str will be applied before sending data to request-json-handler
+; json/write-str will be applied before sending data from request-json-handler
+;   back on the websocket, or when using (send-all! port data)
+(start-ws-server 8000 request-handler-json json/read-str json/write-str)
+
+```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # WebSocket Server
 
 This is the server side of the websocket connection.  This is meant to
-be paired with [juleffel/websocket-client](https://github.com/juleffel/websocket-client).
+be paired with [fentontravers/websocket-client](https://github.com/fentontravers/websocket-client).
 
 # Clojars
 
-![](https://clojars.org/fentontravers/websocket-server/latest-version.svg)
+![https://clojars.org/juleffel/websocket-server/](https://clojars.org/juleffel/websocket-server/latest-version.svg)
   
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WebSocket Server
 
 This is the server side of the websocket connection.  This is meant to
-be paired with [fentontravers/websocket-client](https://github.com/ftravers/websocket-client).
+be paired with [juleffel/websocket-client](https://github.com/juleffel/websocket-client).
 
 # Clojars
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ be paired with [fentontravers/websocket-client](https://github.com/ftravers/webs
 (defn start
   "Demonstrate how to use the websocket server library."
   []
-  (start-ws-server port request-handler-upcase-string))
+  (start-ws-server port :on-receive request-handler-upcase-string))
 
 (defn send-all!
   [data]
@@ -55,9 +55,9 @@ back.
 # Multiple servers usage
 
 ```clojure
-(start-ws-server 8000 request-handler-1)
-(start-ws-server 8001 request-handler-2)
-(start-ws-server 8002 request-handler-3)
+(start-ws-server 8000 :on-receive request-handler-1)
+(start-ws-server 8001 :on-receive request-handler-2)
+(start-ws-server 8002 :on-receive request-handler-3)
 
 ; Send "Hello" to all channels opened to websocket on port 8000
 (send-all! 8000 "Hello")
@@ -85,6 +85,9 @@ back.
 ; json/read-str will be applied before sending data to request-json-handler
 ; json/write-str will be applied before sending data from request-json-handler
 ;   back on the websocket, or when using (send-all! port data)
-(start-ws-server 8000 request-handler-json json/read-str json/write-str)
+(start-ws-server 8000
+  :on-receive request-handler-json
+  :in-fn json/read-str
+  :out-fn json/write-str)
 
 ```

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ be paired with [fentontravers/websocket-client](https://github.com/fentontravers
 
 # Clojars
 
-![https://clojars.org/juleffel/websocket-server/](https://clojars.org/juleffel/websocket-server/latest-version.svg)
-  
+<a href="https://clojars.org/juleffel/websocket-server/" target="_blank">![Foo](https://clojars.org/juleffel/websocket-server/latest-version.svg)]</a>
+
 # Usage
 
 ```clojure

--- a/README.md
+++ b/README.md
@@ -10,11 +10,7 @@ be paired with [fentontravers/websocket-client](https://github.com/ftravers/webs
 # Usage
 
 ```clojure
-(require '[websocket-server.core :refer [start-ws-server]])
-
-;; After we start the server a function is returned
-;; that we use for stopping the server.
-(defonce ws-server (atom nil))
+(require '[websocket-server.core :refer :all])
 
 (defn request-handler-upcase-string
   "The function that will take incoming data off the websocket,
@@ -22,13 +18,22 @@ be paired with [fentontravers/websocket-client](https://github.com/ftravers/webs
   whatever is received."
   [data] (clojure.string/upper-case (str data)))
 
+; Always call this module functions with a port, unless you want to apply it to every server you opened on all ports.
+(def port 8899)
+
 (defn start
   "Demonstrate how to use the websocket server library."
   []
-  (let [port 8899]
-    (reset! ws-server (start-ws-server port request-handler-upcase-string))))
+  (start-ws-server port request-handler-upcase-string))
 
-(defn stop "Stop websocket server" [] (@ws-server))
+(defn send-all!
+  [data]
+  (send-all! port data))
+
+(defn stop
+  "Stop websocket server"
+  []
+  (stop-ws-server port))
 ```
   
 Here is another example that expects EDN in the form of a map that
@@ -45,4 +50,22 @@ back.
        (+ 10)
        (hash-map :count)
        str))
+```
+
+# Multiple servers usage
+
+```clojure
+(start-ws-server 8000 request-handler-1)
+(start-ws-server 8001 request-handler-2)
+(start-ws-server 8002 request-handler-3)
+
+; Send "Hello" to all channels opened to websocket on port 8000
+(send-all! 8000 "Hello")
+
+(stop-ws-server 8002)
+
+; Send "Hi!" to all channels opened to websocket on port 8000 or 8001
+(send-all! "Hello")
+
+(stop-all-ws-servers)
 ```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ back.
 
 ; json/read-str will be applied before sending data to request-json-handler
 ; json/write-str will be applied before sending data from request-json-handler
-;   back on the websocket, or when using (send-all! port data)
+;   back on the websocket, or when using send-all!
 (start-ws-server 8000 request-handler-json json/read-str json/write-str)
 
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ be paired with [fentontravers/websocket-client](https://github.com/fentontravers
 
 # Clojars
 
-<a href="https://clojars.org/juleffel/websocket-server/" target="_blank">![Foo](https://clojars.org/juleffel/websocket-server/latest-version.svg)]</a>
+<a href="https://clojars.org/juleffel/websocket-server/" target="_blank">![Foo](https://clojars.org/juleffel/websocket-server/latest-version.svg)</a>
 
 # Usage
 

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,5 +1,4 @@
 (ns user
-  (:require [clojure.tools.namespace.repl :refer [refresh]]
-            [clojure.repl :refer [doc source]]
+  (:require [clojure.repl :refer [doc source]]
             [clojure.pprint :refer [pprint pp]]
             [clojure.stacktrace :as st]))

--- a/project.clj
+++ b/project.clj
@@ -9,5 +9,9 @@
                  [org.clojure/core.async "0.2.395"]]
   :target-path "target/%s"
 
-  :profiles {:dev {:source-paths ["dev" "src"]}
+  :jvm-opts ["--add-modules" "java.xml.bind"]
+
+  :profiles {:dev {:source-paths ["dev" "src"]
+                   :dependencies [[stylefruits/gniazdo "1.0.1"]
+                                  [org.clojure/core.async "0.4.474"]]}
              :uberjar {:aot :all}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject fentontravers/websocket-server "0.4.12-SNAPSHOT"
+(defproject fentontravers/websocket-server "0.4.12"
   :description "WebSocket Server Library"
   :url "https://github.com/ftravers/websocket-server"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject fentontravers/websocket-server "0.4.12"
+(defproject juleffel/websocket-server "0.4.13"
   :description "WebSocket Server Library"
   :url "https://github.com/ftravers/websocket-server"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -6,10 +6,9 @@
   :dependencies [[org.clojure/clojure "1.9.0-alpha16"]
                  [http-kit "2.2.0"]
                  [com.taoensso/timbre "4.8.0"]
-                 [org.clojure/core.async "0.2.395"]]
+                 [org.clojure/core.async "0.2.395"]
+                 [org.clojure/data.json "0.2.6"]]
   :target-path "target/%s"
-
-  :jvm-opts ["--add-modules" "java.xml.bind"]
 
   :profiles {:dev {:source-paths ["dev" "src"]
                    :dependencies [[stylefruits/gniazdo "1.0.1"]

--- a/src/websocket_server/core.clj
+++ b/src/websocket_server/core.clj
@@ -2,11 +2,18 @@
   (:require [org.httpkit.server :as http]
             [taoensso.timbre :as log]))
 
-(defn websocket-server [cb req]
+; In case we want to start multiple servers, we will keep them as port -> server
+(defonce channel-hub (atom {}))
+(defonce servers (atom {}))
+
+(defn websocket-server [port cb req]
   (http/with-channel req channel
+    (swap! channel-hub assoc-in [port channel] req)
     (http/on-close
      channel
-     (fn [status] (log/debug (str "Websocket channel closed with status: " status))))
+     (fn [status]
+       (log/debug (str "Websocket channel closed with status: " status))
+       (swap! channel-hub update port dissoc channel)))
     (http/on-receive
      channel
      (fn [data]
@@ -16,7 +23,31 @@
            (log/debug "RESP: " resp)
            (http/send! channel resp)))))))
 
-(defn start-ws-server [port callback]
-  (http/run-server (partial websocket-server callback)
-                   {:port port}))
+(defn send-all!
+  ([data]
+   ; Warning: When calling this function without port, you are sending data on every websocket server opened, and every channel
+   (doseq [port (keys @channel-hub)]
+     (send-all! port data)))
+  ([port data]
+   (doseq [channel (keys (@channel-hub port))]
+     (http/send! channel data))))
 
+(defn stop-ws-server [port]
+  (when-not (nil? (@servers port))
+    ;; graceful shutdown: wait 100ms for existing requests to be finished
+    ;; :timeout is optional, when no timeout, stop immediately
+    ((@servers port) :timeout 100)
+    (swap! servers dissoc port)))
+
+(defn start-ws-server [port callback]
+  (if (@servers port)
+    (stop-ws-server port))
+  (let [server
+        (http/run-server (partial websocket-server port callback)
+                         {:port port})]
+    (swap! servers assoc port server)
+    server))
+
+(defn stop-all-ws-servers []
+  (doseq [port (keys @servers)]
+    (stop-ws-server port)))

--- a/test/websocket_server/core_test.clj
+++ b/test/websocket_server/core_test.clj
@@ -14,7 +14,7 @@
 (defn start
   "Demonstrate how to use the websocket server library."
   []
-  (start-ws-server port request-handler-upcase))
+  (start-ws-server port :on-receive request-handler-upcase))
 
 (defn stop
   "Stop websocket server"
@@ -24,7 +24,7 @@
 (defn restart [] (stop) (start))
 
 (deftest send-msg-and-check-resp
-  (start-ws-server port request-handler-upcase)
+  (start-ws-server port :on-receive request-handler-upcase)
   (let [ch (chan)
         client-ws
         (ws/connect
@@ -37,7 +37,7 @@
   (stop-ws-server port))
 
 (deftest send-all-test
-  (start-ws-server port #(throw (Exception. "Shouldn't be called as we are initiating messages on the server side")))
+  (start-ws-server port :on-receive #(throw (Exception. "Shouldn't be called as we are initiating messages on the server side")))
   (let [ch (chan)
         n 3
         clients-ws
@@ -58,7 +58,7 @@
 (deftest multiple-servers-test
   (let [n 3]
     (doseq [i (range 3)]
-      (start-ws-server (+ 8000 i) #(throw (Exception. "Shouldn't be called as we are initiating messages on the server side"))))
+      (start-ws-server (+ 8000 i) :on-receive #(throw (Exception. "Shouldn't be called as we are initiating messages on the server side"))))
     (let [ch (chan)
           clients-ws
           (doall

--- a/test/websocket_server/core_test.clj
+++ b/test/websocket_server/core_test.clj
@@ -1,19 +1,80 @@
 (ns websocket-server.core-test
-  (:require [websocket-server.core :refer [start-ws-server send!]]
-            [clojure.edn :as edn]))
+  (:require
+    [clojure.test :refer :all]
+    [clojure.core.async :refer [chan <!! >!!]]
+    [websocket-server.core :refer :all]
+    [clojure.edn :as edn]
+    [gniazdo.core :as ws]))
 
-(defonce ws-server (atom nil))
+(defn request-handler-upcase [data]
+  (clojure.string/upper-case (str data)))
 
-(defn request-handler-upcase [channel data]
-  (send! channel (clojure.string/upper-case (str data))))
+(def port 7890)
 
-(defn start []
+(defn start
   "Demonstrate how to use the websocket server library."
-  (let [port 7890]
-    (reset! ws-server (start-ws-server port request-handler-upcase))))
+  []
+  (start-ws-server port request-handler-upcase))
 
-(defn stop "Stop websocket server" [] (@ws-server))
+(defn stop
+  "Stop websocket server"
+  []
+  (stop-ws-server port))
 
 (defn restart [] (stop) (start))
 
+(deftest send-msg-and-check-resp
+  (start-ws-server port request-handler-upcase)
+  (let [ch (chan)
+        client-ws
+        (ws/connect
+           (str "ws://localhost:" port)
+           :on-receive #(>!! ch %))]
+    (is (some? client-ws))
+    (ws/send-msg client-ws "Hello")
+    (is (= "HELLO" (<!! ch)))
+    (ws/close client-ws))
+  (stop-ws-server port))
 
+(deftest send-all-test
+  (start-ws-server port #(throw (Exception. "Shouldn't be called as we are initiating messages on the server side")))
+  (let [ch (chan)
+        n 3
+        clients-ws
+        (doall
+          (for [i (range n)]
+            (ws/connect
+              (str "ws://localhost:" port)
+              :on-receive #(>!! ch [i %]))))]
+    (send-all! port "Test")
+    (let [resps (set (repeatedly n #(<!! ch)))]
+      (is (= resps
+             (set (for [i (range n)] [i "Test"]))))
+      (doseq [client-ws clients-ws]
+        (ws/close client-ws))))
+  (stop-ws-server port))
+
+
+(deftest multiple-servers-test
+  (let [n 3]
+    (doseq [i (range 3)]
+      (start-ws-server (+ 8000 i) #(throw (Exception. "Shouldn't be called as we are initiating messages on the server side"))))
+    (let [ch (chan)
+          clients-ws
+          (doall
+            (for [i (range n)]
+              (ws/connect
+                (str "ws://localhost:" (+ 8000 i))
+                :on-receive #(>!! ch [i %]))))]
+      (ws/close (nth clients-ws 2))
+      (stop-ws-server 8002)
+      (send-all! "Test1")
+      (let [resps (set (repeatedly (dec n) #(<!! ch)))]
+        (is (= resps
+               (set (for [i (range (dec n))] [i "Test1"])))))
+      (send-all! 8000 "Test2")
+      (let [resp (<!! ch)]
+        (is (= resp [0 "Test2"])))
+      (ws/close (nth clients-ws 0))
+      (ws/close (nth clients-ws 1))
+      (stop-all-ws-servers))))


### PR DESCRIPTION
The goal of this fork was to be able to initiate messages from the server, without loosing the interest of having handlers.

I also wrote some unit tests, modified the doc.

Important change is also that now the servers opened on different ports are all kept under an atom at the library level, with all the client connections done to these servers.